### PR TITLE
Pull request improve DexDumper

### DIFF
--- a/.github/workflows/android_ndk_build.yml
+++ b/.github/workflows/android_ndk_build.yml
@@ -13,22 +13,24 @@ jobs:
     strategy:
       matrix:
         abi: [armeabi-v7a, arm64-v8a, x86, x86_64]
-    steps:
-      - uses: actions/checkout@v4
 
-      - name: Setup NDK
-        uses: android-actions/setup-ndk@v3
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Android NDK
+        uses: nttld/setup-ndk@v1
         with:
-          ndk-version: 25.2.9519653
+          ndk-version: r25c
 
       - name: Build for ${{ matrix.abi }}
         run: |
-          echo "NDK at: $ANDROID_NDK_HOME"
+          echo "NDK path: $ANDROID_NDK_HOME"
           $ANDROID_NDK_HOME/ndk-build NDK_PROJECT_PATH=. \
             NDK_APPLICATION_MK=./jni/Application.mk \
             APP_ABI=${{ matrix.abi }} V=1
 
-      - name: Upload artifacts
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: DexDumper-${{ matrix.abi }}

--- a/.github/workflows/android_ndk_build.yml
+++ b/.github/workflows/android_ndk_build.yml
@@ -1,32 +1,35 @@
-name: Build DexDumper
+name: Build DexDumper (NDK Multi-ABI)
 
 on:
   push:
     branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+    strategy:
+      matrix:
+        abi: [armeabi-v7a, arm64-v8a, x86, x86_64]
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Setup NDK
-      run: |
-        wget -q https://dl.google.com/android/repository/android-ndk-r25b-linux.zip
-        unzip -q android-ndk-r25b-linux.zip
-        echo "NDK=$(pwd)/android-ndk-r25b" >> $GITHUB_ENV
-        
-    - name: Build
-      run: |
-        $NDK/ndk-build NDK_PROJECT_PATH=. APP_ABI=all
-        
-    - name: Copy output
-      run: |
-        mkdir -p artifacts
-        cp -r libs/* artifacts/
-        
-    - uses: actions/upload-artifact@v4
-      with:
-        name: dexdumper
-        path: artifacts/
+      - uses: actions/checkout@v4
+
+      - name: Setup NDK
+        uses: android-actions/setup-ndk@v3
+        with:
+          ndk-version: 25.2.9519653
+
+      - name: Build for ${{ matrix.abi }}
+        run: |
+          echo "NDK at: $ANDROID_NDK_HOME"
+          $ANDROID_NDK_HOME/ndk-build NDK_PROJECT_PATH=. \
+            NDK_APPLICATION_MK=./jni/Application.mk \
+            APP_ABI=${{ matrix.abi }} V=1
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: DexDumper-${{ matrix.abi }}
+          path: libs/${{ matrix.abi }}/*

--- a/src/common.h
+++ b/src/common.h
@@ -66,6 +66,7 @@ typedef struct {
 typedef struct {
     void* dex_address; // Memory address where DEX file starts
     size_t dex_size;   // Size of the DEX file in bytes
+    char version[4];  //version off detector.c
 } DexDetectionResult;
 
 #endif

--- a/src/dex_detector.c
+++ b/src/dex_detector.c
@@ -1,86 +1,192 @@
 #include "dex_detector.h"
+#include <stdint.h>
+#include <string.h>
+
+
+static const char* const DEX_VERSION_SIGS[] = {
+    "dex\n035\0", "dex\n036\0", "dex\n037\0", 
+    "dex\n038\0", "dex\n039\0", "dex\n040\0"
+};
+static const size_t DEX_VERSION_COUNT = sizeof(DEX_VERSION_SIGS) / sizeof(DEX_VERSION_SIGS[0]);
+
+/**
+ * @brief Fast inline check for DEX magic bytes
+ * @param buf Buffer containing potential DEX signature
+ * @return 1 if valid DEX signature found, 0 otherwise
+ */
+static inline int is_valid_dex_signature(const unsigned char* buf) {
+    // Quick rejection: check "dex\n" prefix first
+    if (buf[0] != 'd' || buf[1] != 'e' || buf[2] != 'x' || buf[3] != '\n') {
+        return 0;
+    }
+    
+    // Check version number (035-040 range)
+    if (buf[4] != '0' || buf[5] != '3' || (buf[6] < '5' || buf[6] > '9')) {
+        // Also check for version 040
+        if (!(buf[4] == '0' && buf[5] == '4' && buf[6] == '0')) {
+            return 0;
+        }
+    }
+    
+    return (buf[7] == '\0'); // Must be null-terminated
+}
 
 /**
  * @brief Validates the structure of a potential DEX header
  * 
- * This function performs comprehensive validation of DEX header fields
- * to distinguish real DEX files from random memory that matches the magic.
+ * Performs comprehensive validation of DEX header fields to distinguish
+ * real DEX files from random memory matching the magic signature.
  * 
- * @param header_start Pointer to the start of memory buffer to check
+ * @param header_start Pointer to the start of memory buffer
  * @param buffer_size Total size of the memory buffer
  * @param header_offset Offset within buffer where header is suspected
  * @return 1 if header is valid, 0 otherwise
  */
 int validate_dex_header_structure(const void* header_start, size_t buffer_size, 
                                  size_t header_offset) {
-    // Basic bounds checking
-    if (header_offset + DEX_HEADER_SIZE > buffer_size) return 0;
+    // Bounds checking with overflow protection
+    if (header_offset > buffer_size || 
+        buffer_size - header_offset < DEX_HEADER_SIZE) {
+        return 0;
+    }
 
+    const unsigned char* header_ptr = (const unsigned char*)header_start + header_offset;
+    
+    // Read and validate file size (offset 0x20)
     uint32_t dex_file_size = 0;
-    // Safely read the file size field from DEX header (offset 0x20)
-    if (!read_memory_safely((const char*)header_start + header_offset + 0x20, 
-                           &dex_file_size, sizeof(uint32_t))) {
+    if (!read_memory_safely(header_ptr + 0x20, &dex_file_size, sizeof(uint32_t))) {
         return 0;
     }
 
     // Validate DEX file size constraints
     if (dex_file_size < DEX_MIN_FILE_SIZE || dex_file_size > DEX_MAX_FILE_SIZE) {
-        LOGW("Invalid DEX file size in header: %u (expected %d-%d)", 
+        LOGW("Invalid DEX file size: %u (range: %d-%d)", 
              dex_file_size, DEX_MIN_FILE_SIZE, DEX_MAX_FILE_SIZE);
         return 0;
     }
 
     // Ensure claimed size fits in available buffer
     if (dex_file_size > (buffer_size - header_offset)) {
-        LOGW("DEX file size %u exceeds available buffer space %zu", 
+        LOGW("DEX size %u exceeds buffer space %zu", 
              dex_file_size, buffer_size - header_offset);
         return 0;
     }
 
-    // Verify header size field (should be 0x70 for standard DEX)
-    uint32_t header_size_value = 0;
-    if (!read_memory_safely((const char*)header_start + header_offset + 0x24, 
-                           &header_size_value, sizeof(uint32_t))) {
+    // Verify header size field (offset 0x24, should be 0x70)
+    uint32_t header_size_val = 0;
+    if (!read_memory_safely(header_ptr + 0x24, &header_size_val, sizeof(uint32_t))) {
         return 0;
     }
     
-    if (header_size_value != DEX_HEADER_SIZE) {
-        LOGW("DEX header size mismatch: %u (expected %u)", 
-             header_size_value, DEX_HEADER_SIZE);
+    if (header_size_val != DEX_HEADER_SIZE) {
+        LOGW("DEX header size mismatch: 0x%x (expected 0x%x)", 
+             header_size_val, DEX_HEADER_SIZE);
         return 0;
     }
 
-    // Check endian tag (should be 0x12345678 for standard DEX)
-    uint32_t endian_tag_value = 0;
-    if (!read_memory_safely((const char*)header_start + header_offset + 0x28, 
-                           &endian_tag_value, sizeof(uint32_t))) {
+    // Check endian tag (offset 0x28, should be 0x12345678)
+    uint32_t endian_tag = 0;
+    if (!read_memory_safely(header_ptr + 0x28, &endian_tag, sizeof(uint32_t))) {
         return 0;
     }
     
-    if (endian_tag_value != 0x12345678U) {
-        LOGW("Unexpected DEX endian tag: 0x%08x", endian_tag_value);
+    if (endian_tag != 0x12345678U) {
+        LOGW("Invalid DEX endian tag: 0x%08x", endian_tag);
         return 0;
     }
 
-    // Validate string table references (common attack vector)
-    uint32_t string_table_size = 0, string_table_offset = 0;
-    if (!read_memory_safely((const char*)header_start + header_offset + 0x38, 
-                           &string_table_size, sizeof(uint32_t))) return 0;
-    if (!read_memory_safely((const char*)header_start + header_offset + 0x3C, 
-                           &string_table_offset, sizeof(uint32_t))) return 0;
+    // Validate link section (offset 0x2C-0x30)
+    uint32_t link_size = 0, link_offset = 0;
+    if (!read_memory_safely(header_ptr + 0x2C, &link_size, sizeof(uint32_t)) ||
+        !read_memory_safely(header_ptr + 0x30, &link_offset, sizeof(uint32_t))) {
+        return 0;
+    }
     
-    // Ensure string table references are within file bounds
-    if (string_table_offset > dex_file_size) return 0;
-    if ((uint64_t)string_table_offset + (uint64_t)string_table_size * 4 > dex_file_size) return 0;
+    if (link_size > 0) {
+        if (link_offset >= dex_file_size || 
+            link_offset + link_size > dex_file_size) {
+            LOGW("Invalid DEX link section: offset=%u, size=%u", link_offset, link_size);
+            return 0;
+        }
+    }
 
-    return 1; // All validation passed
+    // Validate map section (offset 0x34)
+    uint32_t map_offset = 0;
+    if (!read_memory_safely(header_ptr + 0x34, &map_offset, sizeof(uint32_t))) {
+        return 0;
+    }
+    
+    if (map_offset >= dex_file_size) {
+        LOGW("Invalid DEX map offset: %u", map_offset);
+        return 0;
+    }
+
+    // Validate string table (offset 0x38-0x3C)
+    uint32_t string_ids_size = 0, string_ids_off = 0;
+    if (!read_memory_safely(header_ptr + 0x38, &string_ids_size, sizeof(uint32_t)) ||
+        !read_memory_safely(header_ptr + 0x3C, &string_ids_off, sizeof(uint32_t))) {
+        return 0;
+    }
+    
+    if (string_ids_size > 0) {
+        // Each string ID is 4 bytes
+        uint64_t string_table_end = (uint64_t)string_ids_off + 
+                                    ((uint64_t)string_ids_size * 4);
+        if (string_ids_off >= dex_file_size || string_table_end > dex_file_size) {
+            LOGW("Invalid string table: offset=%u, size=%u", string_ids_off, string_ids_size);
+            return 0;
+        }
+    }
+
+    // Validate type IDs section (offset 0x40-0x44)
+    uint32_t type_ids_size = 0, type_ids_off = 0;
+    if (!read_memory_safely(header_ptr + 0x40, &type_ids_size, sizeof(uint32_t)) ||
+        !read_memory_safely(header_ptr + 0x44, &type_ids_off, sizeof(uint32_t))) {
+        return 0;
+    }
+    
+    if (type_ids_size > 0) {
+        uint64_t type_table_end = (uint64_t)type_ids_off + ((uint64_t)type_ids_size * 4);
+        if (type_ids_off >= dex_file_size || type_table_end > dex_file_size) {
+            return 0;
+        }
+    }
+
+    // Validate proto IDs section (offset 0x48-0x4C)
+    uint32_t proto_ids_size = 0, proto_ids_off = 0;
+    if (!read_memory_safely(header_ptr + 0x48, &proto_ids_size, sizeof(uint32_t)) ||
+        !read_memory_safely(header_ptr + 0x4C, &proto_ids_off, sizeof(uint32_t))) {
+        return 0;
+    }
+    
+    if (proto_ids_size > 0) {
+        uint64_t proto_table_end = (uint64_t)proto_ids_off + ((uint64_t)proto_ids_size * 12);
+        if (proto_ids_off >= dex_file_size || proto_table_end > dex_file_size) {
+            return 0;
+        }
+    }
+
+    // Validate method IDs section (offset 0x58-0x5C)
+    uint32_t method_ids_size = 0, method_ids_off = 0;
+    if (!read_memory_safely(header_ptr + 0x58, &method_ids_size, sizeof(uint32_t)) ||
+        !read_memory_safely(header_ptr + 0x5C, &method_ids_off, sizeof(uint32_t))) {
+        return 0;
+    }
+    
+    if (method_ids_size > 0) {
+        uint64_t method_table_end = (uint64_t)method_ids_off + ((uint64_t)method_ids_size * 8);
+        if (method_ids_off >= dex_file_size || method_table_end > dex_file_size) {
+            return 0;
+        }
+    }
+
+    return 1; // All validations passed
 }
 
 /**
- * @brief Scans memory for DEX file signatures
+ * @brief Scans memory for DEX file signatures with optimized algorithm
  * 
- * This function searches through memory for DEX magic bytes and
- * validates any potential matches. It handles multiple DEX versions.
+ * Uses efficient scanning with alignment optimization and early rejection.
  * 
  * @param scan_start Starting address to scan from
  * @param scan_size Size of memory region to scan
@@ -90,57 +196,65 @@ int validate_dex_header_structure(const void* header_start, size_t buffer_size,
  */
 int scan_for_dex_signature(const void* scan_start, size_t scan_size, 
                           size_t max_scan_limit, DexDetectionResult* detection_result) {
-    // Sanity check inputs
-    if (scan_start == NULL || scan_size == 0) return 0;
+    if (scan_start == NULL || detection_result == NULL || scan_size < 8) {
+        return 0;
+    }
     
-    // Calculate actual scanning limit
-    size_t actual_scan_limit = (max_scan_limit > scan_size) ? scan_size : max_scan_limit;
-    if (actual_scan_limit < 8) return 0; // Need at least 8 bytes for signature
+    // Calculate actual scan limit
+    size_t actual_limit = (max_scan_limit < scan_size) ? max_scan_limit : scan_size;
+    if (actual_limit < DEX_HEADER_SIZE) {
+        return 0;
+    }
     
-    unsigned char signature_buffer[8]; // Buffer to read potential signatures
+    const unsigned char* scan_ptr = (const unsigned char*)scan_start;
+    unsigned char sig_buf[8];
     
-    // Scan through memory in 4-byte increments
-    for (size_t current_offset = 0; current_offset <= actual_scan_limit - 8; current_offset += 4) {
-        // Safely read 8 bytes to check for signature
-        if (!read_memory_safely((const char*)scan_start + current_offset, 
-                               signature_buffer, 8)) {
-            continue; // Skip if we can't read this location
+    // Scan with 4-byte alignment for better performance
+    // DEX files are typically 4-byte aligned in memory
+    for (size_t offset = 0; offset <= actual_limit - 8; offset += 4) {
+        // Read potential signature
+        if (!read_memory_safely(scan_ptr + offset, sig_buf, 8)) {
+            continue;
         }
         
-        // Check for DEX signatures with various versions (035-039)
-        if (memcmp(signature_buffer, "dex\n035", 7) == 0 || 
-            memcmp(signature_buffer, "dex\n036", 7) == 0 ||
-            memcmp(signature_buffer, "dex\n037", 7) == 0 ||
-            memcmp(signature_buffer, "dex\n038", 7) == 0 ||
-            memcmp(signature_buffer, "dex\n039", 7) == 0) {
-            
-            VLOGD("Detected DEX signature at offset %zu", current_offset);
-            
-            // Validate the header to confirm it's a real DEX file
-            if (validate_dex_header_structure(scan_start, scan_size, current_offset)) {
-                uint32_t file_size_value = 0;
-                // Read the actual file size from validated header
-                if (read_memory_safely((const char*)scan_start + current_offset + 0x20, 
-                                      &file_size_value, sizeof(uint32_t))) {
-                    detection_result->dex_size = file_size_value;
-                    detection_result->dex_address = (void*)((char*)scan_start + current_offset);
-                    LOGI("Valid DEX file detected at %p, size: %u bytes", 
-                         detection_result->dex_address, file_size_value);
-                    return 1; // Successfully found and validated DEX
-                }
-            } else {
-                LOGW("DEX signature found but header validation failed at offset %zu", 
-                     current_offset);
-            }
+        // Fast signature validation
+        if (!is_valid_dex_signature(sig_buf)) {
+            continue;
         }
+        
+        VLOGD("DEX signature candidate at offset 0x%zx", offset);
+        
+        // Validate complete header structure
+        if (!validate_dex_header_structure(scan_start, scan_size, offset)) {
+            LOGW("DEX signature found but validation failed at offset 0x%zx", offset);
+            continue;
+        }
+        
+        // Read validated file size
+        uint32_t file_size = 0;
+        if (!read_memory_safely(scan_ptr + offset + 0x20, &file_size, sizeof(uint32_t))) {
+            continue;
+        }
+        
+        // Populate result
+        detection_result->dex_address = (void*)(scan_ptr + offset);
+        detection_result->dex_size = file_size;
+        
+        // Extract version info
+        memcpy(detection_result->version, sig_buf + 4, 3);
+        detection_result->version[3] = '\0';
+        
+        LOGI("Valid DEX detected: addr=%p, size=%u, version=%s", 
+             detection_result->dex_address, file_size, detection_result->version);
+        
+        return 1;
     }
-    return 0; // No valid DEX found
+    
+    return 0;
 }
 
 /**
  * @brief Scans a memory region for standard DEX files
- * 
- * Wrapper function that applies size checks before scanning.
  * 
  * @param region_start Start of memory region to scan
  * @param region_size Size of memory region
@@ -149,19 +263,20 @@ int scan_for_dex_signature(const void* scan_start, size_t scan_size,
  */
 int scan_region_for_dex_files(const void* region_start, size_t region_size, 
                              DexDetectionResult* detection_result) {
-    // Skip regions too small to contain a DEX header
-    if (region_size < DEX_HEADER_SIZE) return 0;
+    if (region_size < DEX_HEADER_SIZE) {
+        return 0;
+    }
     
-    // Apply scanning limit to large regions for performance
-    size_t scan_limit = (region_size > DEFAULT_SCAN_LIMIT) ? DEFAULT_SCAN_LIMIT : region_size;
+    size_t scan_limit = (region_size > DEFAULT_SCAN_LIMIT) ? 
+                        DEFAULT_SCAN_LIMIT : region_size;
+    
     return scan_for_dex_signature(region_start, region_size, scan_limit, detection_result);
 }
 
 /**
  * @brief Scans OAT containers for embedded DEX files
  * 
- * OAT files are Android's optimized ART format that often contain
- * embedded DEX files. This function specifically handles OAT containers.
+ * OAT files are Android's optimized ART format containing embedded DEX.
  * 
  * @param region_start Start of memory region
  * @param region_size Size of memory region  
@@ -170,25 +285,66 @@ int scan_region_for_dex_files(const void* region_start, size_t region_size,
  */
 int scan_region_for_oat_dex_files(const void* region_start, size_t region_size, 
                                  DexDetectionResult* detection_result) {
-    // Check for OAT magic signature
-    if (region_size < 8) return 0;
+    if (region_size < 8) {
+        return 0;
+    }
     
-    unsigned char oat_magic[4];
-    if (!read_memory_safely(region_start, oat_magic, 4)) return 0;
+    unsigned char magic[4];
+    if (!read_memory_safely(region_start, magic, 4)) {
+        return 0;
+    }
     
-    // Verify OAT container signature
-    if (memcmp(oat_magic, "oat\n", 4) != 0) return 0;
+    // Check for OAT magic: "oat\n"
+    if (memcmp(magic, "oat\n", 4) != 0) {
+        return 0;
+    }
     
-    VLOGD("Detected OAT container, scanning for embedded DEX");
-    // Scan first 64KB of OAT for embedded DEX (common location)
-    return scan_for_dex_signature(region_start, region_size, 64 * 1024, detection_result);
+    VLOGD("OAT container detected, scanning for embedded DEX");
+    
+    // OAT header is typically followed by DEX within first 128KB
+    size_t oat_scan_limit = (region_size < 128 * 1024) ? region_size : 128 * 1024;
+    
+    return scan_for_dex_signature(region_start, region_size, oat_scan_limit, detection_result);
+}
+
+/**
+ * @brief Scans for VDEX (Verified DEX) files
+ * 
+ * VDEX files contain pre-verified DEX bytecode used by ART.
+ * 
+ * @param region_start Start of memory region
+ * @param region_size Size of memory region
+ * @param detection_result Output for detection results
+ * @return 1 if DEX found in VDEX, 0 otherwise
+ */
+int scan_region_for_vdex_files(const void* region_start, size_t region_size,
+                              DexDetectionResult* detection_result) {
+    if (region_size < 8) {
+        return 0;
+    }
+    
+    unsigned char magic[4];
+    if (!read_memory_safely(region_start, magic, 4)) {
+        return 0;
+    }
+    
+    // Check for VDEX magic: "vdex"
+    if (memcmp(magic, "vdex", 4) != 0) {
+        return 0;
+    }
+    
+    VLOGD("VDEX container detected, scanning for embedded DEX");
+    
+    // VDEX header contains DEX sections, scan first 256KB
+    size_t vdex_scan_limit = (region_size < 256 * 1024) ? region_size : 256 * 1024;
+    
+    return scan_for_dex_signature(region_start, region_size, vdex_scan_limit, detection_result);
 }
 
 /**
  * @brief Performs comprehensive DEX detection using multiple strategies
  * 
- * This function tries different detection methods to find DEX files
- * in various formats and containers.
+ * Tries different detection methods to find DEX files in various formats.
  * 
  * @param region_start Start of memory region to scan
  * @param region_size Size of memory region
@@ -197,25 +353,34 @@ int scan_region_for_oat_dex_files(const void* region_start, size_t region_size,
  */
 int perform_comprehensive_dex_detection(const void* region_start, size_t region_size, 
                                        DexDetectionResult* detection_result) {
-    // Array of detection strategies to try
-    const struct {
-        const char* detection_type;  // Name for logging
-        int (*detector_function)(const void*, size_t, DexDetectionResult*); // Function pointer
-    } detection_strategies[] = {
-        {"standard DEX", scan_region_for_dex_files},    // First try standard DEX
-        {"OAT container", scan_region_for_oat_dex_files} // Then try OAT containers
+    if (region_start == NULL || detection_result == NULL || region_size == 0) {
+        return 0;
+    }
+    
+   
+    typedef int (*DetectorFunc)(const void*, size_t, DexDetectionResult*);
+    
+    static const struct {
+        const char* name;
+        DetectorFunc func;
+    } strategies[] = {
+        {"standard DEX", scan_region_for_dex_files},
+        {"OAT container", scan_region_for_oat_dex_files},
+        {"VDEX container", scan_region_for_vdex_files}
     };
     
-    size_t strategy_count = sizeof(detection_strategies) / sizeof(detection_strategies[0]);
+    const size_t strategy_count = sizeof(strategies) / sizeof(strategies[0]);
     
-    // Try each detection strategy in order
+    
     for (size_t i = 0; i < strategy_count; i++) {
-        VLOGD("Attempting %s detection", detection_strategies[i].detection_type);
-        if (detection_strategies[i].detector_function(region_start, region_size, detection_result)) {
-            LOGI("DEX file detected via %s strategy", detection_strategies[i].detection_type);
-            return 1; // Success with this strategy
+        VLOGD("Trying %s detection strategy", strategies[i].name);
+        
+        if (strategies[i].func(region_start, region_size, detection_result)) {
+            LOGI("DEX detected via %s strategy", strategies[i].name);
+            return 1;
         }
     }
     
-    return 0; // No strategies succeeded
+    VLOGD("No DEX found after trying all detection strategies");
+    return 0;
 }

--- a/src/stealth.c
+++ b/src/stealth.c
@@ -1,5 +1,4 @@
 #include "stealth.h"
-
 #include <pthread.h>
 #include <string.h>
 #include <unistd.h>
@@ -9,7 +8,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-
 #if defined(__linux__) || defined(__ANDROID__)
 #include <sys/syscall.h>
 #include <sys/prctl.h>
@@ -22,6 +20,7 @@
 #ifndef LOGW
 #define LOGW(fmt, ...) __android_log_print(ANDROID_LOG_WARN, "DexDumper", fmt, ##__VA_ARGS__)
 #endif
+
 #ifndef VLOGD
 #define VLOGD(fmt, ...) do { if (verbose_logging) __android_log_print(ANDROID_LOG_DEBUG, "DexDumper", fmt, ##__VA_ARGS__); } while(0)
 #endif
@@ -37,14 +36,14 @@ extern int verbose_logging;
 static uint32_t secure_rand_u32(uint32_t range) {
     if (range == 0) return 0;
     uint32_t v = 0;
-
+    
 #if defined(__NR_getrandom)
     long ret = syscall(__NR_getrandom, &v, sizeof(v), 0);
     if (ret == sizeof(v)) {
         return v % range;
     }
 #endif
-
+    
     int fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
     if (fd >= 0) {
         ssize_t rn = read(fd, &v, sizeof(v));
@@ -53,7 +52,7 @@ static uint32_t secure_rand_u32(uint32_t range) {
             return v % range;
         }
     }
-
+    
     v = (uint32_t)rand();
     return v % range;
 }
@@ -64,14 +63,13 @@ void apply_stealth_techniques(void) {
         "hwuiTask", "RenderThread", "BgThread", "PoolThread",
         "AsyncTask", "Thread", "OkHttp", "Retrofit"
     };
-
     const size_t pool_count = sizeof(thread_name_pool) / sizeof(thread_name_pool[0]);
+    
     uint32_t name_index = secure_rand_u32((uint32_t)pool_count);
-
     char temporary_thread_name[THREAD_NAME_MAX + 1];
     snprintf(temporary_thread_name, sizeof(temporary_thread_name), "%s", thread_name_pool[name_index]);
     temporary_thread_name[THREAD_NAME_MAX] = '\0';
-
+    
 #if defined(__ANDROID__) || defined(_GNU_SOURCE)
     int rc = pthread_setname_np(pthread_self(), temporary_thread_name);
     if (rc != 0) {
@@ -82,15 +80,11 @@ void apply_stealth_techniques(void) {
         LOGW("prctl(PR_SET_NAME) failed: %s", strerror(errno));
     }
 #endif
-
+    
     uint32_t min_ms = 100;
     uint32_t max_ms = 2000;
     uint32_t jitter = min_ms + secure_rand_u32(max_ms - min_ms + 1);
-
     usleep(jitter * 1000U);
+    
     VLOGD("Stealth applied: name='%s', jitter=%ums", temporary_thread_name, jitter);
-}    useconds_t sleep_us = (useconds_t)jitter_ms * 1000U;
-    usleep(sleep_us);
-
-    VLOGD("Stealth applied: name='%s', jitter=%ums", temporary_thread_name, jitter_ms);
 }

--- a/src/stealth.c
+++ b/src/stealth.c
@@ -1,38 +1,104 @@
 #include "stealth.h"
 
-/**
- * @brief Applies anti-detection techniques to hide dumping activity
- * 
- * This function implements various techniques to make the dumping process
- * less conspicuous to detection systems and analysis tools.
- * 
- * Current techniques:
- * - Thread name spoofing: Changes thread name to common Android system names
- * - Random delays: Adds unpredictable timing to avoid pattern detection
- */
-void apply_stealth_techniques() {
-    // Pool of common Android thread names for spoofing
+#include <pthread.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#if defined(__linux__) || defined(__ANDROID__)
+#include <sys/random.h> 
+#include <sys/prctl.h>
+#endif
+
+#ifndef THREAD_NAME_MAX
+#define THREAD_NAME_MAX 15  // 15 chars + '\0' = 16 bytes limit on many kernels 
+#endif
+
+extern int verbose_logging;
+#define VLOGD(fmt, ...) do { if (verbose_logging) __android_log_print(ANDROID_LOG_DEBUG, "DexDumper", fmt, ##__VA_ARGS__); } while(0)
+#define LOGW(fmt, ...) do { __android_log_print(ANDROID_LOG_WARN, "DexDumper", fmt, ##__VA_ARGS__); } while(0)
+
+// scure random in range [0, range-1]. Use getrandom() if available, fallback to /dev/urandom, finally rand().
+static uint32_t secure_rand_u32(uint32_t range) {
+    if (range == 0) return 0;
+    uint32_t v = 0;
+
+#if defined(__linux__) || defined(__ANDROID__)
+    // try getrandom syscall
+    ssize_t r = getrandom(&v, sizeof(v), 0);
+    if (r == (ssize_t)sizeof(v)) {
+        return (uint32_t)(v % range);
+    }
+    // fallback to /dev/urandom
+    int fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+    if (fd >= 0) {
+        ssize_t rn = read(fd, &v, sizeof(v));
+        close(fd);
+        if (rn == (ssize_t)sizeof(v)) {
+            return (uint32_t)(v % range);
+        }
+    }
+#endif
+
+    
+    v = (uint32_t)rand();
+    return (uint32_t)(v % range);
+}
+
+void apply_stealth_techniques(void) {
     const char* thread_name_pool[] = {
-        "Binder:", "JDWP", "Finalizer", "GC", "Signal Catcher",
+        "Binder", "JDWP", "Finalizer", "GC", "SignalC",
         "hwuiTask", "RenderThread", "BgThread", "PoolThread",
         "AsyncTask", "Thread", "OkHttp", "Retrofit"
     };
-    
-    // Randomly select a thread name from the pool
-    int name_index = rand() % (sizeof(thread_name_pool)/sizeof(thread_name_pool[0]));
-    char temporary_thread_name[16];
-    
-    // Copy selected name with bounds checking
-    strncpy(temporary_thread_name, thread_name_pool[name_index], sizeof(temporary_thread_name) - 1);
-    temporary_thread_name[sizeof(temporary_thread_name) - 1] = '\0';
+    const size_t pool_count = sizeof(thread_name_pool) / sizeof(thread_name_pool[0]);
 
-    // Set thread name to spoofed name
-#if defined(_GNU_SOURCE) || defined(__ANDROID__)
-    pthread_setname_np(pthread_self(), temporary_thread_name);
+    // choose random index
+    uint32_t name_index = secure_rand_u32((uint32_t)pool_count);
+
+    char temporary_thread_name[THREAD_NAME_MAX + 1];
+    int n = snprintf(temporary_thread_name, sizeof(temporary_thread_name), "%s", thread_name_pool[name_index]);
+    if (n < 0) {
+        // fallback 
+        snprintf(temporary_thread_name, sizeof(temporary_thread_name), "Thread");
+    } else if (n > THREAD_NAME_MAX) {
+        // ensure null-termination (snprintf already truncates)
+        temporary_thread_name[THREAD_NAME_MAX] = '\0';
+    }
+
+    // set thread name - prefer pthread_setname_np when available
+    int rc = -1;
+#if defined(__ANDROID__) || defined(_GNU_SOURCE)
+    // Many Android / glibc variants support pthread_setname_np(pthread_t, const char*)
+    rc = pthread_setname_np(pthread_self(), temporary_thread_name);
+    if (rc != 0) {
+        VLOGD("pthread_setname_np returned %d (%s)", rc, strerror(rc));
+    } else {
+        VLOGD("Set thread name via pthread_setname_np -> %s", temporary_thread_name);
+    }
 #else
-    prctl(PR_SET_NAME, (unsigned long)temporary_thread_name, 0, 0, 0);
+    errno = 0;
+    if (prctl(PR_SET_NAME, (unsigned long)temporary_thread_name, 0, 0, 0) == 0) {
+        VLOGD("Set thread name via prctl -> %s", temporary_thread_name);
+    } else {
+        LOGW("prctl(PR_SET_NAME) failed: %s", strerror(errno));
+    }
 #endif
 
-    // Add random delay to avoid predictable timing patterns
-    usleep(100000 + (rand() % 400000)); // 100-500ms random delay
+    // random delay between min_ms - max_ms
+    const uint32_t min_ms = 100;   // 100 ms
+    const uint32_t max_ms = 2000;  // 2000 ms
+    uint32_t range = (max_ms - min_ms) + 1;
+    uint32_t jitter_ms = min_ms + secure_rand_u32(range);
+
+    // convert to microseconds for usleep
+    useconds_t sleep_us = (useconds_t)jitter_ms * 1000U;
+    usleep(sleep_us);
+
+    VLOGD("Stealth applied: name='%s', jitter=%ums", temporary_thread_name, jitter_ms);
 }

--- a/src/stealth.c
+++ b/src/stealth.c
@@ -11,93 +11,85 @@
 #include <fcntl.h>
 
 #if defined(__linux__) || defined(__ANDROID__)
-#include <sys/random.h> 
+#include <sys/syscall.h>
 #include <sys/prctl.h>
 #endif
 
 #ifndef THREAD_NAME_MAX
-#define THREAD_NAME_MAX 15  // 15 chars + '\0' = 16 bytes limit on many kernels 
+#define THREAD_NAME_MAX 15
+#endif
+
+#ifndef LOGW
+#define LOGW(fmt, ...) __android_log_print(ANDROID_LOG_WARN, "DexDumper", fmt, ##__VA_ARGS__)
+#endif
+#ifndef VLOGD
+#define VLOGD(fmt, ...) do { if (verbose_logging) __android_log_print(ANDROID_LOG_DEBUG, "DexDumper", fmt, ##__VA_ARGS__); } while(0)
 #endif
 
 extern int verbose_logging;
-#define VLOGD(fmt, ...) do { if (verbose_logging) __android_log_print(ANDROID_LOG_DEBUG, "DexDumper", fmt, ##__VA_ARGS__); } while(0)
-#define LOGW(fmt, ...) do { __android_log_print(ANDROID_LOG_WARN, "DexDumper", fmt, ##__VA_ARGS__); } while(0)
 
-// scure random in range [0, range-1]. Use getrandom() if available, fallback to /dev/urandom, finally rand().
+/**
+ * Secure random with cross-version fallback:
+ * - syscall(__NR_getrandom) for modern kernels
+ * - /dev/urandom fallback
+ * - rand() fallback (least secure)
+ */
 static uint32_t secure_rand_u32(uint32_t range) {
     if (range == 0) return 0;
     uint32_t v = 0;
 
-#if defined(__linux__) || defined(__ANDROID__)
-    // try getrandom syscall
-    ssize_t r = getrandom(&v, sizeof(v), 0);
-    if (r == (ssize_t)sizeof(v)) {
-        return (uint32_t)(v % range);
+#if defined(__NR_getrandom)
+    long ret = syscall(__NR_getrandom, &v, sizeof(v), 0);
+    if (ret == sizeof(v)) {
+        return v % range;
     }
-    // fallback to /dev/urandom
+#endif
+
     int fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
     if (fd >= 0) {
         ssize_t rn = read(fd, &v, sizeof(v));
         close(fd);
-        if (rn == (ssize_t)sizeof(v)) {
-            return (uint32_t)(v % range);
+        if (rn == sizeof(v)) {
+            return v % range;
         }
     }
-#endif
 
-    
     v = (uint32_t)rand();
-    return (uint32_t)(v % range);
+    return v % range;
 }
 
 void apply_stealth_techniques(void) {
-    const char* thread_name_pool[] = {
+    static const char* thread_name_pool[] = {
         "Binder", "JDWP", "Finalizer", "GC", "SignalC",
         "hwuiTask", "RenderThread", "BgThread", "PoolThread",
         "AsyncTask", "Thread", "OkHttp", "Retrofit"
     };
-    const size_t pool_count = sizeof(thread_name_pool) / sizeof(thread_name_pool[0]);
 
-    // choose random index
+    const size_t pool_count = sizeof(thread_name_pool) / sizeof(thread_name_pool[0]);
     uint32_t name_index = secure_rand_u32((uint32_t)pool_count);
 
     char temporary_thread_name[THREAD_NAME_MAX + 1];
-    int n = snprintf(temporary_thread_name, sizeof(temporary_thread_name), "%s", thread_name_pool[name_index]);
-    if (n < 0) {
-        // fallback 
-        snprintf(temporary_thread_name, sizeof(temporary_thread_name), "Thread");
-    } else if (n > THREAD_NAME_MAX) {
-        // ensure null-termination (snprintf already truncates)
-        temporary_thread_name[THREAD_NAME_MAX] = '\0';
-    }
+    snprintf(temporary_thread_name, sizeof(temporary_thread_name), "%s", thread_name_pool[name_index]);
+    temporary_thread_name[THREAD_NAME_MAX] = '\0';
 
-    // set thread name - prefer pthread_setname_np when available
-    int rc = -1;
 #if defined(__ANDROID__) || defined(_GNU_SOURCE)
-    // Many Android / glibc variants support pthread_setname_np(pthread_t, const char*)
-    rc = pthread_setname_np(pthread_self(), temporary_thread_name);
+    int rc = pthread_setname_np(pthread_self(), temporary_thread_name);
     if (rc != 0) {
-        VLOGD("pthread_setname_np returned %d (%s)", rc, strerror(rc));
-    } else {
-        VLOGD("Set thread name via pthread_setname_np -> %s", temporary_thread_name);
+        VLOGD("pthread_setname_np failed: %s", strerror(rc));
     }
 #else
-    errno = 0;
-    if (prctl(PR_SET_NAME, (unsigned long)temporary_thread_name, 0, 0, 0) == 0) {
-        VLOGD("Set thread name via prctl -> %s", temporary_thread_name);
-    } else {
+    if (prctl(PR_SET_NAME, (unsigned long)temporary_thread_name, 0, 0, 0) != 0) {
         LOGW("prctl(PR_SET_NAME) failed: %s", strerror(errno));
     }
 #endif
 
-    // random delay between min_ms - max_ms
-    const uint32_t min_ms = 100;   // 100 ms
-    const uint32_t max_ms = 2000;  // 2000 ms
-    uint32_t range = (max_ms - min_ms) + 1;
-    uint32_t jitter_ms = min_ms + secure_rand_u32(range);
+    uint32_t min_ms = 100;
+    uint32_t max_ms = 2000;
+    uint32_t jitter = min_ms + secure_rand_u32(max_ms - min_ms + 1);
 
-    // convert to microseconds for usleep
-    useconds_t sleep_us = (useconds_t)jitter_ms * 1000U;
+    usleep(jitter * 1000U);
+    VLOGD("Stealth applied: name='%s', jitter=%ums", temporary_thread_name, jitter);
+}    useconds_t sleep_us = (useconds_t)jitter_ms * 1000U;
     usleep(sleep_us);
 
     VLOGD("Stealth applied: name='%s', jitter=%ums", temporary_thread_name, jitter_ms);


### PR DESCRIPTION

### Changes
  - Replaced legacy NDK setup with `setup-ndk@v1`
  - Added multi-ABI matrix build (`armeabi-v7a`, `arm64-v8a`, `x86`, `x86_64`)
  - Enabled `workflow_dispatch` for manual build triggers
  - Uploaded per-ABI artifacts for easier testing
  - Improve stealth.c
  - Added OAT and VDEX scanning improvements in detector.c

### Impact
✅ More stable anti-detection (no predictable thread or timing)  
✅ More stable dex_detector.c

### Verification
- [x] Workflow runs successfully on GitHub Actions  
- [x] All artifacts built correctly (`.so` for all ABIs)  
- [x] Tested locally for stability on Termux/AndroidIDE  